### PR TITLE
dirname(__FILE__)

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * @license http://creativecommons.org/licenses/by-nc-sa/4.0/deed.ru  «Attribution-NonCommercial-ShareAlike»
  */
 
-define('ROOTPATH', __DIR__);
+define('ROOTPATH', dirname(__FILE__));
 
 // Дебаг
 //defined('YII_DEBUG') or define('YII_DEBUG', true);


### PR DESCRIPTION
The magic constant **DIR** is only available as of PHP v.5.3.0
