### PR TITLE
CloudFlare Fix (строки 50-52)

### DIFF
--- a/protected/views/bans/index.php
+++ b/protected/views/bans/index.php
@@ -47,6 +47,9 @@ $('.search-form form').submit(function(){
 <div class="alert alert-<?php echo $check ? 'error' : 'success' ?>">
 	<a href="#" class="close" data-dismiss="alert">&times;</a>
 	<?php 
+	if (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
+		$_SERVER['REMOTE_ADDR'] = $_SERVER["HTTP_CF_CONNECTING_IP"];
+	}
 	$ip = $_SERVER['REMOTE_ADDR'];
 	echo $check
 			?


### PR DESCRIPTION
Здравствуйте. 

Мой сервер и сайты лежат за CDN-прокси, пропускающим через себя трафик - CloudFlare (https://www.cloudflare.com/) (далее - CF) (хабр расскажет об этой вкусняшке - http://habrahabr.ru/post/125823/).

Проблема в том, что при пользовании CF-ом - переменная $_SERVER["REMOTE_ADDR"]; перестает работать и выдает неправильный ip.
В документации CF сказано, что в таком случае необходимо использовать переменную $_SERVER["HTTP_CF_CONNECTING_IP"]; которая будет являться аналогом. 

$_SERVER["HTTP_CF_CONNECTING_IP"]; в отладчике может выбивать ошибку, так и задумано.

На stackoverflow посоветовали использовать именно эту конструкцию с if, которая в коде.
http://stackoverflow.com/questions/14985518/cloudflare-and-logging-visitor-ip-addresses-via-in-php